### PR TITLE
Removed memcpy and conversion from 8 bit to 16 bit in dlf_kernel()

### DIFF
--- a/Source/Lib/Common/ASM_AVX2/EbCdef_AVX2.c
+++ b/Source/Lib/Common/ASM_AVX2/EbCdef_AVX2.c
@@ -98,6 +98,23 @@ static INLINE void mse_4x4_16bit_avx2(const uint16_t **src, const uint16_t *dst,
     *src += 16;
 }
 
+static INLINE void mse_4x4_8bit_avx2(const uint8_t **src, const uint8_t *dst, const int32_t dstride, __m256i *sum) {
+    const __m128i s = _mm_loadu_si128((const __m128i*)*src);
+    const __m128i d = _mm_setr_epi32(
+        *(uint32_t*)(dst + 0 * dstride),
+        *(uint32_t*)(dst + 1 * dstride),
+        *(uint32_t*)(dst + 2 * dstride),
+        *(uint32_t*)(dst + 3 * dstride));
+
+    const __m256i s_16 = _mm256_cvtepu8_epi16(s);
+    const __m256i d_16 = _mm256_cvtepu8_epi16(d);
+
+    const __m256i diff = _mm256_sub_epi16(d_16, s_16);
+    const __m256i mse = _mm256_madd_epi16(diff, diff);
+    *sum = _mm256_add_epi32(*sum, mse);
+    *src += 16;
+}
+
 static INLINE void mse_8x2_16bit_avx2(const uint16_t **src, const uint16_t *dst, const int32_t dstride, __m256i *sum) {
     const __m256i s = _mm256_loadu_si256((const __m256i*)*src);
     const __m128i d0 = _mm_loadu_si128((const __m128i*)(dst + 0 * dstride));
@@ -109,9 +126,28 @@ static INLINE void mse_8x2_16bit_avx2(const uint16_t **src, const uint16_t *dst,
     *src += 16;
 }
 
+static INLINE void mse_8x2_8bit_avx2(const uint8_t **src, const uint8_t *dst, const int32_t dstride, __m256i *sum) {
+    const __m128i s = _mm_loadu_si128((const __m128i*)*src);
+    const __m128i d = _mm_set_epi64x(*(uint64_t*)(dst + 1 * dstride),
+        *(uint64_t*)(dst + 0 * dstride));
+
+    const __m256i s_16 = _mm256_cvtepu8_epi16(s);
+    const __m256i d_16 = _mm256_cvtepu8_epi16(d);
+
+    const __m256i diff = _mm256_sub_epi16(d_16, s_16);
+    const __m256i mse = _mm256_madd_epi16(diff, diff);
+    *sum = _mm256_add_epi32(*sum, mse);
+    *src += 16;
+}
+
 static INLINE void mse_8x4_16bit_avx2(const uint16_t **src, const uint16_t *dst, const int32_t dstride, __m256i *sum) {
     mse_8x2_16bit_avx2(src, dst + 0 * dstride, dstride, sum);
     mse_8x2_16bit_avx2(src, dst + 2 * dstride, dstride, sum);
+}
+
+static INLINE void mse_8x4_8bit_avx2(const uint8_t **src, const uint8_t *dst, const int32_t dstride, __m256i *sum) {
+    mse_8x2_8bit_avx2(src, dst + 0 * dstride, dstride, sum);
+    mse_8x2_8bit_avx2(src, dst + 2 * dstride, dstride, sum);
 }
 
 static INLINE uint32_t sum32(const __m256i src) {
@@ -145,6 +181,55 @@ static INLINE uint64_t dist_8x8_16bit_avx2(const uint16_t **src, const uint16_t 
         s2 = _mm256_add_epi32(s2, _mm256_madd_epi16(s, s));
         sd = _mm256_add_epi32(sd, _mm256_madd_epi16(s, d));
         d2 = _mm256_add_epi32(d2, _mm256_madd_epi16(d, d));
+        *src += 16;
+    }
+
+    ssdd = _mm256_hadd_epi16(ss, dd);
+    ssdd = _mm256_hadd_epi16(ssdd, ssdd);
+    ssdd = _mm256_unpacklo_epi16(ssdd, _mm256_setzero_si256());
+    const __m128i ssdd_L = _mm256_extracti128_si256(ssdd, 0);
+    const __m128i ssdd_H = _mm256_extracti128_si256(ssdd, 1);
+    sum = _mm_add_epi32(ssdd_L, ssdd_H);
+    sum = _mm_hadd_epi32(sum, sum);
+
+    /* Compute the variance -- the calculation cannot go negative. */
+    uint64_t sum_s = _mm_cvtsi128_si32(sum);
+    uint64_t sum_d = _mm_extract_epi32(sum, 1);
+    uint64_t sum_s2 = sum32(s2);
+    uint64_t sum_d2 = sum32(d2);
+    uint64_t sum_sd = sum32(sd);
+
+    /* Compute the variance -- the calculation cannot go negative. */
+    uint64_t svar = sum_s2 - ((sum_s * sum_s + 32) >> 6);
+    uint64_t dvar = sum_d2 - ((sum_d * sum_d + 32) >> 6);
+    return (uint64_t)floor(
+        .5 + (sum_d2 + sum_s2 - 2 * sum_sd) * .5 *
+        (svar + dvar + (400 << 2 * coeff_shift)) /
+        (sqrt((20000 << 4 * coeff_shift) + svar * (double)dvar)));
+}
+
+static INLINE uint64_t dist_8x8_8bit_avx2(const uint8_t **src, const uint8_t *dst, const int32_t dstride, const int32_t coeff_shift) {
+    __m256i ss = _mm256_setzero_si256();
+    __m256i dd = _mm256_setzero_si256();
+    __m256i s2 = _mm256_setzero_si256();
+    __m256i sd = _mm256_setzero_si256();
+    __m256i d2 = _mm256_setzero_si256();
+    __m256i ssdd;
+    __m128i sum;
+
+    for (int32_t r = 0; r < 4; r++) {
+        const __m128i s = _mm_loadu_si128((const __m128i*)*src);
+        const __m128i d = _mm_set_epi64x(*(uint64_t*)(dst + 2 * r * dstride + 1 * dstride),
+            *(uint64_t*)(dst + 2 * r * dstride + 0 * dstride));
+
+        const __m256i s_16 = _mm256_cvtepu8_epi16(s);
+        const __m256i d_16 = _mm256_cvtepu8_epi16(d);
+
+        ss = _mm256_add_epi16(ss, s_16);
+        dd = _mm256_add_epi16(dd, d_16);
+        s2 = _mm256_add_epi32(s2, _mm256_madd_epi16(s_16, s_16));
+        sd = _mm256_add_epi32(sd, _mm256_madd_epi16(s_16, d_16));
+        d2 = _mm256_add_epi32(d2, _mm256_madd_epi16(d_16, d_16));
         *src += 16;
     }
 
@@ -247,5 +332,65 @@ uint64_t compute_cdef_dist_avx2(const uint16_t *dst, int32_t dstride, const uint
         sum = sum64(mse64);
     }
 
+    return sum >> 2 * coeff_shift;
+}
+
+uint64_t compute_cdef_dist_8bit_avx2(const uint8_t *dst8, int32_t dstride, const uint8_t *src8, const cdef_list *dlist, int32_t cdef_count, BlockSize bsize, int32_t coeff_shift, int32_t pli) {
+    uint64_t sum;
+    int32_t bi, bx, by;
+
+    if ((bsize == BLOCK_8X8) && (pli == 0)) {
+        sum = 0;
+        for (bi = 0; bi < cdef_count; bi++) {
+            by = dlist[bi].by;
+            bx = dlist[bi].bx;
+            sum += dist_8x8_8bit_avx2(&src8, dst8 + 8 * by * dstride + 8 * bx, dstride, coeff_shift);
+        }
+    }
+    else {
+        __m256i mse64 = _mm256_setzero_si256();
+
+        if (bsize == BLOCK_8X8) {
+            for (bi = 0; bi < cdef_count; bi++) {
+                __m256i mse32 = _mm256_setzero_si256();
+                by = dlist[bi].by;
+                bx = dlist[bi].bx;
+                mse_8x4_8bit_avx2(&src8, dst8 + (8 * by + 0) * dstride + 8 * bx, dstride, &mse32);
+                mse_8x4_8bit_avx2(&src8, dst8 + (8 * by + 4) * dstride + 8 * bx, dstride, &mse32);
+                sum_32_to_64(mse32, &mse64);
+            }
+        }
+        else if (bsize == BLOCK_4X8) {
+            for (bi = 0; bi < cdef_count; bi++) {
+                __m256i mse32 = _mm256_setzero_si256();
+                by = dlist[bi].by;
+                bx = dlist[bi].bx;
+                mse_4x4_8bit_avx2(&src8, dst8 + (8 * by + 0) * dstride + 4 * bx, dstride, &mse32);
+                mse_4x4_8bit_avx2(&src8, dst8 + (8 * by + 4) * dstride + 4 * bx, dstride, &mse32);
+                sum_32_to_64(mse32, &mse64);
+            }
+        }
+        else if (bsize == BLOCK_8X4) {
+            for (bi = 0; bi < cdef_count; bi++) {
+                __m256i mse32 = _mm256_setzero_si256();
+                by = dlist[bi].by;
+                bx = dlist[bi].bx;
+                mse_8x4_8bit_avx2(&src8, dst8 + 4 * by * dstride + 8 * bx, dstride, &mse32);
+                sum_32_to_64(mse32, &mse64);
+            }
+        }
+        else {
+            assert(bsize == BLOCK_4X4);
+            for (bi = 0; bi < cdef_count; bi++) {
+                __m256i mse32 = _mm256_setzero_si256();
+                by = dlist[bi].by;
+                bx = dlist[bi].bx;
+                mse_4x4_8bit_avx2(&src8, dst8 + 4 * by * dstride + 4 * bx, dstride, &mse32);
+                sum_32_to_64(mse32, &mse64);
+            }
+        }
+
+        sum = sum64(mse64);
+    }
     return sum >> 2 * coeff_shift;
 }

--- a/Source/Lib/Common/ASM_AVX2/v256_intrinsics_x86.h
+++ b/Source/Lib/Common/ASM_AVX2/v256_intrinsics_x86.h
@@ -39,7 +39,7 @@ SIMD_INLINE v64 v256_low_v64(v256 a) {
 }
 
 SIMD_INLINE v128 v256_low_v128(v256 a) {
-    return _mm256_extracti128_si256(a, 0);
+    return _mm256_castsi256_si128(a);
 }
 
 SIMD_INLINE v128 v256_high_v128(v256 a) {

--- a/Source/Lib/Common/Codec/EbCdefProcess.c
+++ b/Source/Lib/Common/Codec/EbCdefProcess.c
@@ -29,6 +29,9 @@ static int32_t priconv[REDUCED_PRI_STRENGTHS] = { 0, 1, 2, 3, 5, 7, 10, 13 };
 void copy_sb16_16(uint16_t *dst, int32_t dstride, const uint16_t *src,
     int32_t src_voffset, int32_t src_hoffset, int32_t sstride,
     int32_t vsize, int32_t hsize);
+void copy_sb8_16(uint16_t *dst, int32_t dstride,
+    const uint8_t *src, int32_t src_voffset, int32_t src_hoffset,
+    int32_t sstride, int32_t vsize, int32_t hsize);
 
 void *eb_aom_memalign(size_t align, size_t size);
 void eb_aom_free(void *memblk);
@@ -96,12 +99,13 @@ void cdef_seg_search(
     int32_t mi_cols = pPcs->av1_cm->mi_cols;
 
     uint32_t fbr, fbc;
-    uint16_t *src[3];
-    uint16_t *ref_coeff[3];
+    uint8_t *src[3];
+    uint8_t *ref_coeff[3];
     cdef_list dlist[MI_SIZE_128X128 * MI_SIZE_128X128];
     int32_t dir[CDEF_NBLOCKS][CDEF_NBLOCKS] = { { 0 } };
     int32_t var[CDEF_NBLOCKS][CDEF_NBLOCKS] = { { 0 } };
-    int32_t stride[3];
+    int32_t stride_src[3];
+    int32_t stride_ref[3];
     int32_t bsize[3];
     int32_t mi_wide_l2[3];
     int32_t mi_high_l2[3];
@@ -119,12 +123,19 @@ void cdef_seg_search(
     const int32_t total_strengths = fast ? REDUCED_TOTAL_STRENGTHS : TOTAL_STRENGTHS;
     DECLARE_ALIGNED(32, uint16_t, inbuf[CDEF_INBUF_SIZE]);
     uint16_t *in;
-    DECLARE_ALIGNED(32, uint16_t, tmp_dst[1 << (MAX_SB_SIZE_LOG2 * 2)]);
+    DECLARE_ALIGNED(32, uint8_t, tmp_dst[1 << (MAX_SB_SIZE_LOG2 * 2)]);
 
     int32_t gi_step;
     int32_t mid_gi;
     int32_t start_gi;
     int32_t end_gi;
+
+    EbPictureBufferDesc *input_picture_ptr = (EbPictureBufferDesc*)picture_control_set_ptr->parent_pcs_ptr->enhanced_picture_ptr;
+    EbPictureBufferDesc  * recon_picture_ptr;
+    if (picture_control_set_ptr->parent_pcs_ptr->is_used_as_reference_flag == EB_TRUE)
+        recon_picture_ptr = ((EbReferenceObject*)picture_control_set_ptr->parent_pcs_ptr->reference_picture_wrapper_ptr->object_ptr)->reference_picture;
+    else
+        recon_picture_ptr = picture_control_set_ptr->recon_picture_ptr;
 
     for (pli = 0; pli < num_planes; pli++) {
         int32_t subsampling_x = (pli == 0) ? 0 : 1;
@@ -133,13 +144,13 @@ void cdef_seg_search(
         ydec[pli] = subsampling_y;
         bsize[pli] = ydec[pli] ? (xdec[pli] ? BLOCK_4X4 : BLOCK_8X4)
             : (xdec[pli] ? BLOCK_4X8 : BLOCK_8X8);
-        stride[pli] = cm->mi_cols << MI_SIZE_LOG2;
         mi_wide_l2[pli] = MI_SIZE_LOG2 - subsampling_x;
         mi_high_l2[pli] = MI_SIZE_LOG2 - subsampling_y;
 
-        src[pli] = picture_control_set_ptr->src[pli];
-        ref_coeff[pli] = picture_control_set_ptr->ref_coeff[pli];
-        stride[pli] = pli > 0 ? stride[pli] >> 1 : stride[pli];
+        src[pli] = (uint8_t *)picture_control_set_ptr->src[pli];
+        ref_coeff[pli] = (uint8_t *)picture_control_set_ptr->ref_coeff[pli];
+        stride_src[pli]= pli == 0 ? recon_picture_ptr->stride_y : (pli == 1 ? recon_picture_ptr->stride_cb : recon_picture_ptr->stride_cr);
+        stride_ref[pli]= pli == 0 ? input_picture_ptr->stride_y : (pli == 1 ? input_picture_ptr->stride_cb : input_picture_ptr->stride_cr);
     }
 
     in = inbuf + CDEF_VBORDER * CDEF_BSTRIDE + CDEF_HBORDER;
@@ -190,12 +201,12 @@ void cdef_seg_search(
                 int32_t ysize = (nvb << mi_high_l2[pli]) + CDEF_VBORDER * ((int32_t)fbr + vb_step < nvfb) + yoff;
                 int32_t xsize = (nhb << mi_wide_l2[pli]) + CDEF_HBORDER * ((int32_t)fbc + hb_step < nhfb) + xoff;
 
-                copy_sb16_16(
+                copy_sb8_16(
                     &in[(-yoff * CDEF_BSTRIDE - xoff)], CDEF_BSTRIDE,
                     src[pli],
                     (fbr * MI_SIZE_64X64 << mi_high_l2[pli]) - yoff,
                     (fbc * MI_SIZE_64X64 << mi_wide_l2[pli]) - xoff,
-                    stride[pli], ysize, xsize);
+                    stride_src[pli], ysize, xsize);
                 gi_step = get_cdef_gi_step(pPcs->cdef_filter_mode);
                 mid_gi = pPcs->cdf_ref_frame_strenght;
                 start_gi = pPcs->use_ref_frame_cdef_strength && pPcs->cdef_filter_mode == 1 ? (AOMMAX(0, mid_gi - gi_step)) : 0;
@@ -211,16 +222,17 @@ void cdef_seg_search(
                     average are outside the frame. We could change the filter instead, but it would add special cases for any future vectorization. */
                     sec_strength = gi % CDEF_SEC_STRENGTHS;
 
-                    eb_cdef_filter_fb(NULL, tmp_dst, CDEF_BSTRIDE, in, xdec[pli], ydec[pli],
+                    eb_cdef_filter_fb(tmp_dst, NULL, CDEF_BSTRIDE, in, xdec[pli], ydec[pli],
                         dir, &dirinit, var, pli, dlist, cdef_count, threshold,
                         sec_strength + (sec_strength == 3), pri_damping,
                         sec_damping, coeff_shift);
 
-                    curr_mse = eb_compute_cdef_dist(
+
+                    curr_mse = eb_compute_cdef_dist_8bit(
                         ref_coeff[pli] +
-                        (fbr * MI_SIZE_64X64 << mi_high_l2[pli]) * stride[pli] +
+                        (fbr * MI_SIZE_64X64 << mi_high_l2[pli]) * stride_ref[pli] +
                         (fbc * MI_SIZE_64X64 << mi_wide_l2[pli]),
-                        stride[pli], tmp_dst, dlist, cdef_count, (BlockSize)bsize[pli], coeff_shift,
+                        stride_ref[pli], tmp_dst, dlist, cdef_count, (BlockSize)bsize[pli], coeff_shift,
                         pli);
 
                     if (pli < 2)

--- a/Source/Lib/Common/Codec/EbDlfProcess.c
+++ b/Source/Lib/Common/Codec/EbDlfProcess.c
@@ -196,7 +196,6 @@ void* dlf_kernel(void *input_ptr)
                 }
                 else
                 {
-                    //these copies should go!
                     EbByte  rec_ptr = &((recon_picture_ptr->buffer_y)[recon_picture_ptr->origin_x + recon_picture_ptr->origin_y * recon_picture_ptr->stride_y]);
                     EbByte  rec_ptr_cb = &((recon_picture_ptr->buffer_cb)[recon_picture_ptr->origin_x / 2 + recon_picture_ptr->origin_y / 2 * recon_picture_ptr->stride_cb]);
                     EbByte  rec_ptr_cr = &((recon_picture_ptr->buffer_cr)[recon_picture_ptr->origin_x / 2 + recon_picture_ptr->origin_y / 2 * recon_picture_ptr->stride_cr]);
@@ -206,21 +205,14 @@ void* dlf_kernel(void *input_ptr)
                     EbByte  enh_ptr_cb = &((input_picture_ptr->buffer_cb)[input_picture_ptr->origin_x / 2 + input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_cb]);
                     EbByte  enh_ptr_cr = &((input_picture_ptr->buffer_cr)[input_picture_ptr->origin_x / 2 + input_picture_ptr->origin_y / 2 * input_picture_ptr->stride_cr]);
 
-                    for (int r = 0; r < sequence_control_set_ptr->seq_header.max_frame_height; ++r) {
-                        for (int c = 0; c < sequence_control_set_ptr->seq_header.max_frame_width; ++c) {
-                        picture_control_set_ptr->src[0]      [r * sequence_control_set_ptr->seq_header.max_frame_width + c] = rec_ptr[r * recon_picture_ptr->stride_y + c];
-                        picture_control_set_ptr->ref_coeff[0][r * sequence_control_set_ptr->seq_header.max_frame_width + c] = enh_ptr[r * input_picture_ptr->stride_y + c];
-                        }
-                    }
+                    picture_control_set_ptr->src[0] = (uint16_t*)rec_ptr;
+                    picture_control_set_ptr->src[1] = (uint16_t*)rec_ptr_cb;
+                    picture_control_set_ptr->src[2] = (uint16_t*)rec_ptr_cr;
 
-                for (int r = 0; r < sequence_control_set_ptr->seq_header.max_frame_height/2; ++r) {
-                    for (int c = 0; c < sequence_control_set_ptr->seq_header.max_frame_width /2; ++c) {
-                        picture_control_set_ptr->src[1][r * sequence_control_set_ptr->seq_header.max_frame_width /2 + c] = rec_ptr_cb[r * recon_picture_ptr->stride_cb + c];
-                        picture_control_set_ptr->ref_coeff[1][r * sequence_control_set_ptr->seq_header.max_frame_width /2 + c] = enh_ptr_cb[r * input_picture_ptr->stride_cb + c];
-                            picture_control_set_ptr->src[2][r * sequence_control_set_ptr->seq_header.max_frame_width / 2 + c] = rec_ptr_cr[r * recon_picture_ptr->stride_cr + c];
-                            picture_control_set_ptr->ref_coeff[2][r * sequence_control_set_ptr->seq_header.max_frame_width / 2 + c] = enh_ptr_cr[r * input_picture_ptr->stride_cr + c];
-                        }
-                    }
+                    picture_control_set_ptr->ref_coeff[0] = (uint16_t*)enh_ptr;
+                    picture_control_set_ptr->ref_coeff[1] = (uint16_t*)enh_ptr_cb;
+                    picture_control_set_ptr->ref_coeff[2] = (uint16_t*)enh_ptr_cr;
+
                 }
             }
         }

--- a/Source/Lib/Common/Codec/EbPictureControlSet.c
+++ b/Source/Lib/Common/Codec/EbPictureControlSet.c
@@ -203,13 +203,6 @@ void picture_control_set_dctor(EbPtr p)
     EB_FREE_ARRAY(obj->mse_seg[0]);
     EB_FREE_ARRAY(obj->mse_seg[1]);
 
-    EB_FREE_ARRAY(obj->src[0]);
-    EB_FREE_ARRAY(obj->ref_coeff[0]);
-    EB_FREE_ARRAY(obj->src[1]);
-    EB_FREE_ARRAY(obj->ref_coeff[1]);
-    EB_FREE_ARRAY(obj->src[2]);
-    EB_FREE_ARRAY(obj->ref_coeff[2]);
-
     EB_FREE_ARRAY(obj->mi_grid_base);
     EB_FREE_ARRAY(obj->mip);
 #if ENABLE_CDF_UPDATE
@@ -998,16 +991,6 @@ EbErrorType picture_control_set_ctor(
 
     EB_MALLOC_ARRAY(object_ptr->mse_seg[0], pictureLcuWidth * pictureLcuHeight);
     EB_MALLOC_ARRAY(object_ptr->mse_seg[1], pictureLcuWidth * pictureLcuHeight);
-
-    if (!is16bit)
-    {
-        EB_MALLOC_ARRAY(object_ptr->src[0], initDataPtr->picture_width * initDataPtr->picture_height);
-        EB_MALLOC_ARRAY(object_ptr->ref_coeff[0], initDataPtr->picture_width * initDataPtr->picture_height);
-        EB_MALLOC_ARRAY(object_ptr->src[1], initDataPtr->picture_width * initDataPtr->picture_height * 3 / 2);
-        EB_MALLOC_ARRAY(object_ptr->ref_coeff[1],initDataPtr->picture_width * initDataPtr->picture_height * 3 / 2);
-        EB_MALLOC_ARRAY(object_ptr->src[2], initDataPtr->picture_width * initDataPtr->picture_height * 3 / 2);
-        EB_MALLOC_ARRAY(object_ptr->ref_coeff[2], initDataPtr->picture_width * initDataPtr->picture_height * 3 / 2);
-    }
 
     EB_CREATE_MUTEX(object_ptr->rest_search_mutex);
 

--- a/Source/Lib/Common/Codec/aom_dsp_rtcd.h
+++ b/Source/Lib/Common/Codec/aom_dsp_rtcd.h
@@ -81,6 +81,9 @@ extern "C" {
     uint64_t compute_cdef_dist_c(const uint16_t *dst, int32_t dstride, const uint16_t *src, const cdef_list *dlist, int32_t cdef_count, BlockSize bsize, int32_t coeff_shift, int32_t pli);
     uint64_t compute_cdef_dist_avx2(const uint16_t *dst, int32_t dstride, const uint16_t *src, const cdef_list *dlist, int32_t cdef_count, BlockSize bsize, int32_t coeff_shift, int32_t pli);
     RTCD_EXTERN uint64_t(*eb_compute_cdef_dist)(const uint16_t *dst, int32_t dstride, const uint16_t *src, const cdef_list *dlist, int32_t cdef_count, BlockSize bsize, int32_t coeff_shift, int32_t pli);
+    uint64_t compute_cdef_dist_8bit_c(const uint8_t *dst8, int32_t dstride, const uint8_t *src8, const cdef_list *dlist, int32_t cdef_count, BlockSize bsize, int32_t coeff_shift, int32_t pli);
+    uint64_t compute_cdef_dist_8bit_avx2(const uint8_t *dst8, int32_t dstride, const uint8_t *src8, const cdef_list *dlist, int32_t cdef_count, BlockSize bsize, int32_t coeff_shift, int32_t pli);
+    RTCD_EXTERN uint64_t(*eb_compute_cdef_dist_8bit)(const uint8_t *dst8, int32_t dstride, const uint8_t *src8, const cdef_list *dlist, int32_t cdef_count, BlockSize bsize, int32_t coeff_shift, int32_t pli);
     void eb_copy_rect8_8bit_to_16bit_c(uint16_t *dst, int32_t dstride, const uint8_t *src, int32_t sstride, int32_t v, int32_t h);
     void eb_copy_rect8_8bit_to_16bit_avx2(uint16_t *dst, int32_t dstride, const uint8_t *src, int32_t sstride, int32_t v, int32_t h);
     RTCD_EXTERN void(*eb_copy_rect8_8bit_to_16bit)(uint16_t *dst, int32_t dstride, const uint8_t *src, int32_t sstride, int32_t v, int32_t h);
@@ -2425,6 +2428,8 @@ extern "C" {
         if (flags & HAS_AVX2) eb_cdef_filter_block = eb_cdef_filter_block_avx2;
         eb_compute_cdef_dist = compute_cdef_dist_c;
         if (flags & HAS_AVX2) eb_compute_cdef_dist = compute_cdef_dist_avx2;
+        eb_compute_cdef_dist_8bit = compute_cdef_dist_8bit_c;
+        if (flags & HAS_AVX2) eb_compute_cdef_dist_8bit = compute_cdef_dist_8bit_avx2;
 
         eb_copy_rect8_8bit_to_16bit = eb_copy_rect8_8bit_to_16bit_c;
         if (flags & HAS_AVX2) eb_copy_rect8_8bit_to_16bit = eb_copy_rect8_8bit_to_16bit_avx2;


### PR DESCRIPTION
Removed memcpy and conversion from 8 bit to 16 bit in  dlf_kernel() with CDEF updated accordingly 

Fixed 10bit-option crash for msvc debugger attached (free unallocated memory, 10 bit video is different, more bytes are written to out file)